### PR TITLE
Add npm audit report

### DIFF
--- a/reports/npm-audit.md
+++ b/reports/npm-audit.md
@@ -1,0 +1,15 @@
+# NPM Dependency Audit
+
+## Summary
+- `npm audit` failed because the repository does not contain a `package-lock.json` or `npm-shrinkwrap.json` file.
+- The absence of a lockfile indicates that no Node.js package manifest exists in the project root, so there are no npm-managed dependencies to audit.
+
+## Recommendations
+1. If the project intentionally omits Node.js dependencies, no action is required.
+2. If Node.js tooling is expected:
+   - Add a `package.json` and commit the dependency graph.
+   - Run `npm install --package-lock-only` to generate a lockfile before auditing.
+   - Re-run `npm audit` after the lockfile exists to capture known vulnerabilities.
+
+## Command Output
+See the command transcript for the exact error emitted by `npm audit` when no lockfile is present.


### PR DESCRIPTION
## Summary
- document the outcome of attempting to run `npm audit` and the lack of Node.js dependencies

## Testing
- npm audit *(fails: requires an existing lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68de402cac3c8330939099ec9f81f156